### PR TITLE
 Add set -e to fail fast

### DIFF
--- a/scripts/healthchecks.sh
+++ b/scripts/healthchecks.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate

--- a/scripts/megakiller.sh
+++ b/scripts/megakiller.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate

--- a/scripts/megakiller.sh
+++ b/scripts/megakiller.sh
@@ -3,4 +3,5 @@ set -e
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate
+/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform destroy -auto-approve"

--- a/scripts/megalister.sh
+++ b/scripts/megalister.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 ln -s /usr/bin/chromedriver /usr/sbin/chromedriver
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars

--- a/scripts/megalister.sh
+++ b/scripts/megalister.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
+
+find some-files
+find /app
+
 ln -s /usr/bin/chromedriver /usr/sbin/chromedriver
 cp some-files/id_caasp /app/caasp-openstack-terraform/ssh/id_caasp
 chmod 0500 /app/caasp-openstack-terraform/ssh/id_caasp

--- a/scripts/megalister.sh
+++ b/scripts/megalister.sh
@@ -5,6 +5,7 @@ find some-files
 find /app
 
 ln -s /usr/bin/chromedriver /usr/sbin/chromedriver
+mkdir -p /app/caasp-openstack-terraform/ssh/
 cp some-files/id_caasp /app/caasp-openstack-terraform/ssh/id_caasp
 chmod 0500 /app/caasp-openstack-terraform/ssh/id_caasp
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf

--- a/scripts/megalister.sh
+++ b/scripts/megalister.sh
@@ -6,6 +6,7 @@ chmod 0500 /app/caasp-openstack-terraform/ssh/id_caasp
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate
+/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform refresh"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -caaspuiinst
 cp /app/caasp-openstack-terraform/caasp-cluster.tf some-files/caasp-cluster.tf

--- a/scripts/megarunner.sh
+++ b/scripts/megarunner.sh
@@ -5,6 +5,8 @@ function copy_some_files {
 	cp /app/caasp-openstack-terraform/terraform.tfstate some-files/terraform.tfstate
 	cp /app/caasp-openstack-terraform/ssh/id_caasp some-files/id_caasp
 	cat /app/caasp-openstack-terraform/terraform.tfstate
+	find some-files
+	find /app
 }
 
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"

--- a/scripts/megarunner.sh
+++ b/scripts/megarunner.sh
@@ -2,6 +2,8 @@
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -createcaasp -action apply
 #/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform output" > some-files/out.json
+ls -l /app
+ls -l /app/caasp-openstack-terraform
 cp /app/caasp-openstack-terraform/caasp-cluster.tf some-files/caasp-cluster.tf
 cp /app/caasp-openstack-terraform/terraform.tfvars some-files/terraform.tfvars
 cp /app/caasp-openstack-terraform/terraform.tfstate some-files/terraform.tfstate

--- a/scripts/megarunner.sh
+++ b/scripts/megarunner.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
+set -e
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -createcaasp -action apply
 #/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform output" > some-files/out.json
-ls -l /app
-ls -l /app/caasp-openstack-terraform
 cp /app/caasp-openstack-terraform/caasp-cluster.tf some-files/caasp-cluster.tf
 cp /app/caasp-openstack-terraform/terraform.tfvars some-files/terraform.tfvars
 cp /app/caasp-openstack-terraform/terraform.tfstate some-files/terraform.tfstate

--- a/scripts/megarunner.sh
+++ b/scripts/megarunner.sh
@@ -1,10 +1,22 @@
 #!/bin/sh
-set -e
+function copy_some_files {
+	cp /app/caasp-openstack-terraform/caasp-cluster.tf some-files/caasp-cluster.tf
+	cp /app/caasp-openstack-terraform/terraform.tfvars some-files/terraform.tfvars
+	cp /app/caasp-openstack-terraform/terraform.tfstate some-files/terraform.tfstate
+	cp /app/caasp-openstack-terraform/ssh/id_caasp some-files/id_caasp
+	cat /app/caasp-openstack-terraform/terraform.tfstate
+}
+
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
+if [ $? -ne 0 ]; then
+	copy_some_files
+	return 1
+fi
+
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -createcaasp -action apply
+if [ $? -ne 0 ]; then
+	copy_some_files
+	return 1
+fi
+copy_some_files
 #/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform output" > some-files/out.json
-cp /app/caasp-openstack-terraform/caasp-cluster.tf some-files/caasp-cluster.tf
-cp /app/caasp-openstack-terraform/terraform.tfvars some-files/terraform.tfvars
-cp /app/caasp-openstack-terraform/terraform.tfstate some-files/terraform.tfstate
-cp /app/caasp-openstack-terraform/ssh/id_caasp some-files/id_caasp
-cat /app/caasp-openstack-terraform/terraform.tfstate

--- a/scripts/megaupdater.sh
+++ b/scripts/megaupdater.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate

--- a/scripts/megaupdater.sh
+++ b/scripts/megaupdater.sh
@@ -5,6 +5,7 @@ cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate
 cp some-files/id_caasp /app/caasp-openstack-terraform/id_caasp
 chmod 0500 /app/caasp-openstack-terraform/id_caasp
+/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -reg
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -dis
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ar $1

--- a/scripts/megaupdaterII.sh
+++ b/scripts/megaupdaterII.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate

--- a/scripts/megaupdaterII.sh
+++ b/scripts/megaupdaterII.sh
@@ -5,6 +5,7 @@ cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate
 cp some-files/id_caasp /app/caasp-openstack-terraform/id_caasp
 chmod 0500 /app/caasp-openstack-terraform/id_caasp
+/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -reg
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -dis
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -cmd "zypper -n --gpg-auto-import-keys ref"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 cd /usr/sbin/
 ln -s /usr/bin/chromedriver chromedriver
 go run /app/proto/main.go

--- a/scripts/updatethepackage.sh
+++ b/scripts/updatethepackage.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 cp some-files/caasp-cluster.tf /app/caasp-openstack-terraform/caasp-cluster.tf
 cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate

--- a/scripts/updatethepackage.sh
+++ b/scripts/updatethepackage.sh
@@ -5,6 +5,7 @@ cp some-files/terraform.tfvars /app/caasp-openstack-terraform/terraform.tfvars
 cp some-files/terraform.tfstate /app/caasp-openstack-terraform/terraform.tfstate
 cp some-files/id_caasp /app/caasp-openstack-terraform/id_caasp
 chmod 0500 /app/caasp-openstack-terraform/id_caasp
+/app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ostkcmd "terraform init"
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -dis
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -ar $1
 /app/mkcaasp -repo /app/caasp-openstack-terraform -auth openstack.json -cmd "zypper -n --gpg-auto-import-keys ref"


### PR DESCRIPTION
With `set -e` the scripts will fail if for example terraform isn't able to setup.  
A first step to clean up our setup and find bugs earlier. 